### PR TITLE
Feat/#1/kakao maps api

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import Script from 'next/script';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -15,8 +16,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang='en'>
-      <body className={inter.className}>{children}</body>
+    <html lang='ko'>
+      <body className={inter.className}>
+        <Script
+          strategy='beforeInteractive'
+          src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&autoload=false&libraries=services`}
+        ></Script>
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,30 @@ declare global {
 export default function Home() {
   const mapRef = useRef<HTMLDivElement>(null);
   const [map, setMap] = useState<any>(null);
+  const [ps, setPs] = useState<any>(null);
+
+  const placesSearchCB = (data, status, pagination) => {
+    if (status === window.kakao.maps.services.Status.OK) {
+      const bounds = new window.kakao.maps.LatLngBounds();
+      console.log(data);
+      for (let i = 0; i < data.length; i++) {
+        displayMarker(data[i]);
+        bounds.extend(new window.kakao.maps.LatLng(data[i].y, data[i].x));
+      }
+
+      // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+      map.setBounds(bounds);
+    } else {
+      console.log('검색 실패', window.kakao.maps.services.Status);
+    }
+  };
+
+  const displayMarker = place => {
+    const marker = new window.kakao.maps.Marker({
+      map,
+      position: new window.kakao.maps.LatLng(place.y, place.x),
+    });
+  };
 
   useEffect(() => {
     window.kakao.maps.load(() => {
@@ -20,8 +44,19 @@ export default function Home() {
       };
 
       setMap(new window.kakao.maps.Map(mapRef.current, options));
+      setPs(new window.kakao.maps.services.Places());
     });
   }, []);
+
+  useEffect(() => {
+    if (!map) return;
+    if (!ps) return;
+    ps.setMap(map);
+    ps.keywordSearch('빽다방', placesSearchCB, {
+      useMapCenter: true,
+      radius: 1000,
+    });
+  }, [map, ps]);
 
   return <div ref={mapRef} className='h-96 w-96'></div>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,27 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
 export default function Home() {
-  return <div>main</div>;
+  const mapRef = useRef<HTMLDivElement>(null);
+  const [map, setMap] = useState<any>(null);
+
+  useEffect(() => {
+    window.kakao.maps.load(() => {
+      const options = {
+        //지도를 생성할 때 필요한 기본 옵션
+        center: new window.kakao.maps.LatLng(37.639888, 126.791622), //지도의 중심좌표.
+        level: 3, //지도의 레벨(확대, 축소 정도)
+      };
+
+      setMap(new window.kakao.maps.Map(mapRef.current, options));
+    });
+  }, []);
+
+  return <div ref={mapRef} className='h-96 w-96'></div>;
 }


### PR DESCRIPTION
## 개요 :mag:

Kakao Maps  API 스크립트 적용, 지도 생성 및 키워드 검색

## 작업사항 :memo:

- Kakao Maps  API 스크립트 적용을 했습니다.  스크립트 태그에 strategy='beforeInteractive'를 적용하여 페이지 하이드레이션이 발생하기 전에 스크립트를 로드 시켰습니다. 다만 해당 스크립트에 관한 타입이 정의되지 않아 any 처리를 한 후 지도를 생성하였습니다.
-  관련 이슈 : #1 
