### PR TITLE
Feat/#1/kakao maps api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "next-caffeine-station",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.0.1",
         "next": "14.0.4",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-redux": "^9.1.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -451,6 +453,29 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.0.1.tgz",
+      "integrity": "sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.0",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.6.1.tgz",
@@ -490,13 +515,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.47",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.47.tgz",
       "integrity": "sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -516,13 +541,18 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.18.1",
@@ -1311,7 +1341,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2524,6 +2554,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -3866,6 +3905,32 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-redux": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+      "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "react-native": ">=0.69",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3885,6 +3950,19 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -3929,6 +4007,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -4758,6 +4841,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.0.1",
     "next": "14.0.4",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-redux": "^9.1.0"
   },
   "devDependencies": {
     "@types/node": "^20",
@@ -26,10 +28,10 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-tailwindcss": "^3.13.1",
+    "husky": "^8.0.0",
     "postcss": "^8",
     "prettier": "^3.2.2",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5",
-    "husky": "^8.0.0"
+    "typescript": "^5"
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
-import './globals.css';
 import Script from 'next/script';
+import './globals.css';
+import Provider from '@/components/Provider';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -22,7 +23,7 @@ export default function RootLayout({
           strategy='beforeInteractive'
           src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&autoload=false&libraries=services`}
         ></Script>
-        {children}
+        <Provider>{children}</Provider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,11 +11,12 @@ export default function Home() {
   const mapRef = useRef<HTMLDivElement>(null);
   const [map, setMap] = useState<any>(null);
   const [ps, setPs] = useState<any>(null);
+  const [cafes, setCafes] = useState<any[]>([]);
 
   const placesSearchCB = (data, status, pagination) => {
     if (status === window.kakao.maps.services.Status.OK) {
+      setCafes(pre => [...pre, ...data]);
       const bounds = new window.kakao.maps.LatLngBounds();
-      console.log(data);
       for (let i = 0; i < data.length; i++) {
         displayMarker(data[i]);
         bounds.extend(new window.kakao.maps.LatLng(data[i].y, data[i].x));
@@ -61,8 +62,19 @@ export default function Home() {
     if (!map) return;
     if (!ps) return;
     ps.setMap(map);
-    keywordsSearch(['뺵다방', '메가커피', '컴포즈커피']);
+    keywordsSearch(['빽다방', '메가커피', '컴포즈커피']);
   }, [map, ps]);
 
-  return <div ref={mapRef} className='h-96 w-96'></div>;
+  console.log(cafes);
+
+  return (
+    <>
+      <div ref={mapRef} className='h-96 w-96'></div>
+      <ul>
+        {cafes.map(cafe => (
+          <li key={cafe.id}>{cafe.place_name}</li>
+        ))}
+      </ul>
+    </>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,15 @@ export default function Home() {
     });
   };
 
+  const keywordsSearch = (keywords: string[]) => {
+    keywords.map(keyword => {
+      ps.keywordSearch(keyword, placesSearchCB, {
+        useMapCenter: true,
+        radius: 3000,
+      });
+    });
+  };
+
   useEffect(() => {
     window.kakao.maps.load(() => {
       const options = {
@@ -52,10 +61,7 @@ export default function Home() {
     if (!map) return;
     if (!ps) return;
     ps.setMap(map);
-    ps.keywordSearch('빽다방', placesSearchCB, {
-      useMapCenter: true,
-      radius: 1000,
-    });
+    keywordsSearch(['뺵다방', '메가커피', '컴포즈커피']);
   }, [map, ps]);
 
   return <div ref={mapRef} className='h-96 w-96'></div>;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,80 +1,11 @@
-'use client';
-import { useEffect, useRef, useState } from 'react';
-
-declare global {
-  interface Window {
-    kakao: any;
-  }
-}
+import Map from '@/components/Map';
+import CafeList from '@/components/main/CafeList';
 
 export default function Home() {
-  const mapRef = useRef<HTMLDivElement>(null);
-  const [map, setMap] = useState<any>(null);
-  const [ps, setPs] = useState<any>(null);
-  const [cafes, setCafes] = useState<any[]>([]);
-
-  const placesSearchCB = (data, status, pagination) => {
-    if (status === window.kakao.maps.services.Status.OK) {
-      setCafes(pre => [...pre, ...data]);
-      const bounds = new window.kakao.maps.LatLngBounds();
-      for (let i = 0; i < data.length; i++) {
-        displayMarker(data[i]);
-        bounds.extend(new window.kakao.maps.LatLng(data[i].y, data[i].x));
-      }
-
-      // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
-      map.setBounds(bounds);
-    } else {
-      console.log('검색 실패', window.kakao.maps.services.Status);
-    }
-  };
-
-  const displayMarker = place => {
-    const marker = new window.kakao.maps.Marker({
-      map,
-      position: new window.kakao.maps.LatLng(place.y, place.x),
-    });
-  };
-
-  const keywordsSearch = (keywords: string[]) => {
-    keywords.map(keyword => {
-      ps.keywordSearch(keyword, placesSearchCB, {
-        useMapCenter: true,
-        radius: 3000,
-      });
-    });
-  };
-
-  useEffect(() => {
-    window.kakao.maps.load(() => {
-      const options = {
-        //지도를 생성할 때 필요한 기본 옵션
-        center: new window.kakao.maps.LatLng(37.639888, 126.791622), //지도의 중심좌표.
-        level: 3, //지도의 레벨(확대, 축소 정도)
-      };
-
-      setMap(new window.kakao.maps.Map(mapRef.current, options));
-      setPs(new window.kakao.maps.services.Places());
-    });
-  }, []);
-
-  useEffect(() => {
-    if (!map) return;
-    if (!ps) return;
-    ps.setMap(map);
-    keywordsSearch(['빽다방', '메가커피', '컴포즈커피']);
-  }, [map, ps]);
-
-  console.log(cafes);
-
   return (
     <>
-      <div ref={mapRef} className='h-96 w-96'></div>
-      <ul>
-        {cafes.map(cafe => (
-          <li key={cafe.id}>{cafe.place_name}</li>
-        ))}
-      </ul>
+      <Map />
+      <CafeList />
     </>
   );
 }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+
+import { setMap } from '@/redux/slices/mapSlice';
+import useCurrentLocation from '@/hooks/useCurrentLocation';
+import { useAppDispatch } from '@/redux/store';
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+const Map = () => {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const dispatch = useAppDispatch();
+  const { coords, error } = useCurrentLocation();
+
+  useEffect(() => {
+    if (!coords) return;
+    window.kakao.maps.load(() => {
+      const options = {
+        //지도를 생성할 때 필요한 기본 옵션
+        center: new window.kakao.maps.LatLng(coords.latitude, coords.longitude), //지도의 중심좌표.
+        level: 3, //지도의 레벨(확대, 축소 정도)
+      };
+      const newMap = new window.kakao.maps.Map(mapRef.current, options);
+      dispatch(setMap(newMap));
+    });
+  }, [coords]);
+
+  return (
+    <>
+      <div ref={mapRef} className='h-96 w-96'></div>
+    </>
+  );
+};
+
+export default Map;

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -1,0 +1,9 @@
+'use client';
+import { Provider as ReduxProvider } from 'react-redux';
+import { store } from '@/redux/store';
+
+const Provider = ({ children }: { children: React.ReactNode }) => {
+  return <ReduxProvider store={store}>{children}</ReduxProvider>;
+};
+
+export default Provider;

--- a/src/components/main/Cafe.tsx
+++ b/src/components/main/Cafe.tsx
@@ -1,0 +1,8 @@
+import { CafeType } from '@/types';
+import React from 'react';
+
+const Cafe = ({ cafe }: { cafe: CafeType }) => {
+  return <div>{cafe.place_name}</div>;
+};
+
+export default Cafe;

--- a/src/components/main/CafeList.tsx
+++ b/src/components/main/CafeList.tsx
@@ -1,0 +1,67 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { useAppSelector } from '@/redux/store';
+import { CafeType } from '@/types';
+import Cafe from './Cafe';
+
+const CafeList = () => {
+  const { map } = useAppSelector(state => state.map);
+  const [ps, setPs] = useState<any>(null);
+  const [cafes, setCafes] = useState<CafeType[]>([]);
+
+  const placesSearchCB = (data: CafeType[], status: string) => {
+    if (status === window.kakao.maps.services.Status.OK) {
+      setCafes(pre => [...pre, ...data]);
+      const bounds = new window.kakao.maps.LatLngBounds();
+      for (let i = 0; i < data.length; i++) {
+        displayMarker(data[i]);
+        bounds.extend(new window.kakao.maps.LatLng(data[i].y, data[i].x));
+      }
+
+      // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+      map.setBounds(bounds);
+    } else {
+      console.log('검색 실패', window.kakao.maps.services.Status);
+    }
+  };
+
+  const displayMarker = (place: CafeType) => {
+    const marker = new window.kakao.maps.Marker({
+      map,
+      position: new window.kakao.maps.LatLng(place.y, place.x),
+    });
+  };
+
+  const keywordsSearch = (keywords: string[]) => {
+    keywords.map(keyword => {
+      ps.keywordSearch(keyword, placesSearchCB, {
+        useMapCenter: true,
+        radius: 3000,
+      });
+    });
+  };
+
+  useEffect(() => {
+    window.kakao.maps.load(() => {
+      setPs(new window.kakao.maps.services.Places());
+    });
+  }, []);
+
+  useEffect(() => {
+    if (ps && map) {
+      ps.setMap(map);
+      keywordsSearch(['빽다방', '메가커피', '컴포즈커피']);
+    }
+  }, [ps, map]);
+
+  return (
+    <div>
+      <span>CafeList</span>
+      {cafes.map(cafe => (
+        <Cafe key={cafe.id} cafe={cafe} />
+      ))}
+    </div>
+  );
+};
+
+export default CafeList;

--- a/src/hooks/useCurrentLocation.ts
+++ b/src/hooks/useCurrentLocation.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { CoordsType } from '@/types';
+
+const useCurrentLocation = () => {
+  const [coords, setCoords] = useState<CoordsType | null>(null);
+  const [error, setError] = useState<GeolocationPositionError | null>(null);
+
+  const onSuccess = ({
+    coords: { latitude, longitude },
+  }: GeolocationPosition) => {
+    setCoords({ latitude, longitude });
+  };
+
+  const onError = (err: GeolocationPositionError) => {
+    setError(err);
+  };
+
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(onSuccess, onError);
+  }, []);
+
+  return { coords, error };
+};
+
+export default useCurrentLocation;

--- a/src/redux/slices/mapSlice.ts
+++ b/src/redux/slices/mapSlice.ts
@@ -1,0 +1,18 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+type Map = { map: any };
+
+const initialState: Map = { map: null };
+
+const mapSlice = createSlice({
+  name: 'Map',
+  initialState,
+  reducers: {
+    setMap(state, action) {
+      state.map = action.payload;
+    },
+  },
+});
+
+export const { setMap } = mapSlice.actions;
+export default mapSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,0 +1,18 @@
+import { configureStore } from '@reduxjs/toolkit';
+import mapSlice from './slices/mapSlice';
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+
+export const store = configureStore({
+  reducer: {
+    map: mapSlice,
+  },
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
+});
+
+export const useAppDispatch: () => typeof store.dispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<
+  ReturnType<typeof store.getState>
+> = useSelector;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,19 @@
+export interface CoordsType {
+  latitude: number;
+  longitude: number;
+}
+
+export interface CafeType {
+  address_name: string;
+  category_group_code: string;
+  category_group_name: string;
+  category_name: string;
+  distance: string;
+  id: string;
+  phone: string;
+  place_name: string;
+  place_url: string;
+  road_address_name: string;
+  x: string;
+  y: string;
+}


### PR DESCRIPTION
## 개요 :mag:

Kakao Maps API 스크립트 적용, 지도 생성 및 키워드 검색

## 작업사항 :memo:

- 카카오 지도 객체와 검색 서비스 객체를 컴포넌트로 나누기 위해 카카오 지도 객체를 Redux를 사용하여 전역 상태로 관리하였습니다. 카카오 지도 객체가 직렬화 할 수 없는 값이라 Redux의 미들웨어 설정에서  serializableCheck를 false로 설정하였습니다.
-  관련 이슈 : #1 
- close : #1
