### PR TITLE
Feat/#4/지도 데이터 필터링

### DIFF
--- a/src/components/main/CafeList.tsx
+++ b/src/components/main/CafeList.tsx
@@ -5,6 +5,7 @@ import { CafeType, CoordsType } from '@/types';
 import jsxToString from '@/libs/client/jsxToString';
 import Cafe from './Cafe';
 import CafeOverlay from './CafeOverlay';
+import Provider from '../Provider';
 
 interface CafeListProps {
   distance: number;
@@ -16,7 +17,8 @@ const CafeList = ({ distance, kerwords, coords }: CafeListProps) => {
   const { map } = useAppSelector(state => state.map);
   const [ps, setPs] = useState<any>(null);
   const [cafes, setCafes] = useState<CafeType[]>([]);
-  const [markers, setMarkers] = useState<any[]>([]);
+  // const [markers, setMarkers] = useState<any[]>([]);
+  const [overlay, setOverlay] = useState<any[]>([]);
 
   const placesSearchCB = (data: CafeType[], status: string) => {
     if (status === window.kakao.maps.services.Status.OK) {
@@ -34,17 +36,26 @@ const CafeList = ({ distance, kerwords, coords }: CafeListProps) => {
     // setMarkers(pre => [...pre, marker]);
     const overlay = new window.kakao.maps.CustomOverlay({
       position: new window.kakao.maps.LatLng(place.y, place.x),
-      content: jsxToString(<CafeOverlay cafe={place} />),
+      content: jsxToString(
+        <Provider>
+          <CafeOverlay cafe={place} />
+        </Provider>,
+      ),
       removavle: false,
     });
     overlay.setMap(map);
+    setOverlay(pre => [...pre, overlay]);
   };
 
   const removeMarker = () => {
-    for (let i = 0; i < markers.length; i++) {
-      markers[i].setMap(null);
+    // for (let i = 0; i < markers.length; i++) {
+    //   markers[i].setMap(null);
+    // }
+    // setMarkers([]);
+    for (let i = 0; i < overlay.length; i++) {
+      overlay[i].setMap(null);
     }
-    setMarkers([]);
+    setOverlay([]);
   };
 
   const keywordsSearch = (keywords: string[]) => {
@@ -95,7 +106,7 @@ const CafeList = ({ distance, kerwords, coords }: CafeListProps) => {
   }, [cafes]);
 
   return (
-    <div>
+    <div className='absolute right-0 top-0 z-10'>
       <span>CafeList</span>
       {cafes.map(cafe => (
         <Cafe key={cafe.id} cafe={cafe} />

--- a/src/components/main/CafeList.tsx
+++ b/src/components/main/CafeList.tsx
@@ -2,7 +2,9 @@
 import React, { useEffect, useState } from 'react';
 import { useAppSelector } from '@/redux/store';
 import { CafeType, CoordsType } from '@/types';
+import jsxToString from '@/libs/client/jsxToString';
 import Cafe from './Cafe';
+import CafeOverlay from './CafeOverlay';
 
 interface CafeListProps {
   distance: number;
@@ -25,11 +27,17 @@ const CafeList = ({ distance, kerwords, coords }: CafeListProps) => {
   };
 
   const displayMarker = (place: CafeType) => {
-    const marker = new window.kakao.maps.Marker({
-      map,
+    // const marker = new window.kakao.maps.Marker({
+    //   map,
+    //   position: new window.kakao.maps.LatLng(place.y, place.x),
+    // });
+    // setMarkers(pre => [...pre, marker]);
+    const overlay = new window.kakao.maps.CustomOverlay({
       position: new window.kakao.maps.LatLng(place.y, place.x),
+      content: jsxToString(<CafeOverlay cafe={place} />),
+      removavle: false,
     });
-    setMarkers(pre => [...pre, marker]);
+    overlay.setMap(map);
   };
 
   const removeMarker = () => {

--- a/src/components/main/CafeOverlay.tsx
+++ b/src/components/main/CafeOverlay.tsx
@@ -1,0 +1,22 @@
+import { brands } from '@/content';
+import { CafeType } from '@/types';
+
+interface CafeOverlayProps {
+  cafe: CafeType;
+}
+
+const CafeOverlay = ({ cafe }: CafeOverlayProps) => {
+  const brand = brands.filter(brand => {
+    if (cafe.place_name.includes(brand.name)) {
+      return brand;
+    }
+  });
+
+  return (
+    <div className='rounded-xl border bg-white px-2 py-1'>
+      {brand[0] && brand[0].hot}원
+    </div>
+  );
+};
+
+export default CafeOverlay;

--- a/src/components/main/CafeOverlay.tsx
+++ b/src/components/main/CafeOverlay.tsx
@@ -1,4 +1,5 @@
 import { brands } from '@/content';
+import { useAppSelector } from '@/redux/store';
 import { CafeType } from '@/types';
 
 interface CafeOverlayProps {
@@ -12,9 +13,28 @@ const CafeOverlay = ({ cafe }: CafeOverlayProps) => {
     }
   });
 
+  const { mode, isHot } = useAppSelector(state => state.filter);
+
   return (
     <div className='rounded-xl border bg-white px-2 py-1'>
-      {brand[0] && brand[0].hot}원
+      <span>
+        {mode === 'price' && isHot && `${brand[0].hot.price}원/잔`}
+        {mode === 'mlPrice' &&
+          isHot &&
+          `${Math.round((brand[0].hot.price / brand[0].hot.amount) * 100)}원/100ml`}
+        {mode === 'caffeinePrice' &&
+          isHot &&
+          `${Math.round((brand[0].hot.caffeine / brand[0].hot.amount) * 100)}원/100ml`}
+      </span>
+      <span>
+        {mode === 'price' && !isHot && `${brand[0].ice.price}원/잔`}
+        {mode === 'mlPrice' &&
+          !isHot &&
+          `${Math.round((brand[0].ice.price / brand[0].ice.amount) * 100)}원/100ml`}
+        {mode === 'caffeinePrice' &&
+          !isHot &&
+          `${Math.round((brand[0].ice.caffeine / brand[0].ice.amount) * 100)}원/100ml`}
+      </span>
     </div>
   );
 };

--- a/src/components/main/FilteringController.tsx
+++ b/src/components/main/FilteringController.tsx
@@ -1,3 +1,5 @@
+import { setIsHot, setMode } from '@/redux/slices/filterSlice';
+import { useAppDispatch } from '@/redux/store';
 import React, { Dispatch, SetStateAction } from 'react';
 
 interface FilteringControllerProps {
@@ -11,6 +13,7 @@ const FilteringController = ({
   setDistance,
   setKeywords,
 }: FilteringControllerProps) => {
+  const dispatch = useAppDispatch();
   const onDistanceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const {
       target: { value },
@@ -44,6 +47,40 @@ const FilteringController = ({
       <div className='flex gap-4'>
         <span onClick={() => onKeywordsChange('가성비')}>가성비</span>
         <span onClick={() => onKeywordsChange('프리미엄')}>프리미엄</span>
+      </div>
+      <div className='flex gap-2'>
+        <div
+          className='cursor-pointer font-light'
+          onClick={() => dispatch(setMode('price'))}
+        >
+          가격(잔)
+        </div>
+        <div
+          className='cursor-pointer font-light'
+          onClick={() => dispatch(setMode('mlPrice'))}
+        >
+          가격(ml)
+        </div>
+        <div
+          className='cursor-pointer font-light'
+          onClick={() => dispatch(setMode('caffeinePrice'))}
+        >
+          카페인가격(ml)
+        </div>
+      </div>
+      <div className='flex gap-2'>
+        <div
+          className='cursor-pointer font-light'
+          onClick={() => dispatch(setIsHot(true))}
+        >
+          HOT
+        </div>
+        <div
+          className='cursor-pointer font-light'
+          onClick={() => dispatch(setIsHot(false))}
+        >
+          ICE
+        </div>
       </div>
     </div>
   );

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,0 +1,28 @@
+const paikdabang = {
+  name: '빽다방',
+  hot: 1500,
+  ice: 2000,
+  caffeine: 237,
+  menu: [
+    {
+      menuName: '앗!메리카노',
+      type: 'hot',
+      size: 'one_size',
+      price: 1500,
+      amount: 400,
+      kcal: 14,
+      caffeine: 237,
+    },
+    {
+      menuName: '앗!메리카노',
+      type: 'ice',
+      size: 'one_size',
+      price: 2000,
+      amount: 625,
+      kcal: 13,
+      caffeine: 237,
+    },
+  ],
+};
+
+export const brands = [paikdabang];

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,28 +1,182 @@
 const paikdabang = {
   name: '빽다방',
-  hot: 1500,
-  ice: 2000,
-  caffeine: 237,
+  hot: { price: 1500, amount: 400, caffeine: 237 },
+  ice: { price: 2000, amount: 625, caffeine: 237 },
   menu: [
     {
       menuName: '앗!메리카노',
-      type: 'hot',
-      size: 'one_size',
-      price: 1500,
-      amount: 400,
-      kcal: 14,
-      caffeine: 237,
-    },
-    {
-      menuName: '앗!메리카노',
-      type: 'ice',
-      size: 'one_size',
-      price: 2000,
-      amount: 625,
-      kcal: 13,
-      caffeine: 237,
+      kind: [
+        {
+          type: 'hot',
+          size: 'one_size',
+          price: 1500,
+          amount: 400,
+          kcal: 14,
+          caffeine: 237,
+        },
+        {
+          type: 'ice',
+          size: 'one_size',
+          price: 2000,
+          amount: 625,
+          kcal: 13,
+          caffeine: 237,
+        },
+      ],
     },
   ],
 };
 
-export const brands = [paikdabang];
+const megaCoffee = {
+  name: '메가MGC커피',
+  hot: { price: 1500, amount: 567, caffeine: 204.2 },
+  ice: { price: 2000, amount: 680, caffeine: 199.7 },
+  menu: [
+    {
+      menuName: '아메리카노',
+      kind: [
+        {
+          type: 'hot',
+          size: 'one_size',
+          price: 1500,
+          amount: 567,
+          kcal: 12.2,
+          caffeine: 204.2,
+        },
+        {
+          type: 'ice',
+          size: 'one_size',
+          price: 2000,
+          amount: 680,
+          kcal: 12.2,
+          caffeine: 199.7,
+        },
+      ],
+    },
+  ],
+};
+
+const composeCoffee = {
+  name: '컴포즈커피',
+  hot: { price: 1500, amount: 567, caffeine: 156 },
+  ice: { price: 1500, amount: 567, caffeine: 156 },
+  menu: [
+    {
+      menuName: '아메리카노',
+      kind: [
+        {
+          type: 'hot',
+          size: 'one_size',
+          price: 1500,
+          amount: 567,
+          kcal: 15,
+          caffeine: 156,
+        },
+        {
+          type: 'ice',
+          size: 'one_size',
+          price: 1500,
+          amount: 567,
+          kcal: 15,
+          caffeine: 156,
+        },
+      ],
+    },
+  ],
+};
+
+const starbucks = {
+  name: '스타벅스',
+  hot: { price: 4500, amount: 355, caffeine: 150 },
+  ice: { price: 4500, amount: 355, caffeine: 150 },
+  menu: [
+    {
+      menuName: '아메리카노',
+      kind: [
+        {
+          type: 'hot',
+          size: 'one_size',
+          price: 4500,
+          amount: 355,
+          kcal: 10,
+          caffeine: 150,
+        },
+        {
+          type: 'ice',
+          size: 'one_size',
+          price: 4500,
+          amount: 355,
+          kcal: 10,
+          caffeine: 150,
+        },
+      ],
+    },
+  ],
+};
+
+const paulbassett = {
+  name: '폴바셋',
+  hot: { price: 4700, amount: 360, caffeine: 160 },
+  ice: { price: 4700, amount: 360, caffeine: 160 },
+  menu: [
+    {
+      menuName: '아메리카노',
+      kind: [
+        {
+          type: 'hot',
+          size: 'one_size',
+          price: 4700,
+          amount: 360,
+          kcal: 10,
+          caffeine: 160,
+        },
+        {
+          type: 'ice',
+          size: 'one_size',
+          price: 4700,
+          amount: 360,
+          kcal: 10,
+          caffeine: 160,
+        },
+      ],
+    },
+  ],
+};
+
+const twosome = {
+  name: '투썸플레이스',
+  hot: { price: 4500, amount: 355, caffeine: 160 },
+  ice: { price: 4500, amount: 355, caffeine: 160 },
+  menu: [
+    {
+      menuName: '아메리카노',
+      kind: [
+        {
+          type: 'hot',
+          size: 'one_size',
+          price: 4500,
+          amount: 355,
+          kcal: 15,
+          caffeine: 160,
+        },
+        {
+          type: 'ice',
+          size: 'one_size',
+          price: 4500,
+          amount: 355,
+          kcal: 15,
+          caffeine: 160,
+        },
+      ],
+    },
+  ],
+};
+
+export const brands = [
+  paikdabang,
+  megaCoffee,
+  composeCoffee,
+  starbucks,
+  paulbassett,
+  twosome,
+];

--- a/src/libs/client/jsxToString.ts
+++ b/src/libs/client/jsxToString.ts
@@ -1,0 +1,11 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+const jsxToString = (jsx: React.ReactNode) => {
+  const div = document.createElement('div');
+  const root = createRoot(div);
+  root.render(jsx);
+  return div;
+};
+
+export default jsxToString;

--- a/src/redux/slices/filterSlice.ts
+++ b/src/redux/slices/filterSlice.ts
@@ -1,0 +1,24 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface FilterType {
+  mode: 'price' | 'mlPrice' | 'caffeinePrice';
+  isHot: boolean;
+}
+
+const initialState: FilterType = { mode: 'price', isHot: true };
+
+const filterSlice = createSlice({
+  name: 'Filter',
+  initialState,
+  reducers: {
+    setMode(state, action) {
+      state.mode = action.payload;
+    },
+    setIsHot(state, action) {
+      state.isHot = action.payload;
+    },
+  },
+});
+
+export const { setMode, setIsHot } = filterSlice.actions;
+export default filterSlice.reducer;

--- a/src/redux/slices/mapSlice.ts
+++ b/src/redux/slices/mapSlice.ts
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-type Map = { map: any };
+type MapType = { map: any };
 
-const initialState: Map = { map: null };
+const initialState: MapType = { map: null };
 
 const mapSlice = createSlice({
   name: 'Map',

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import mapSlice from './slices/mapSlice';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import filterSlice from './slices/filterSlice';
 
 export const store = configureStore({
   reducer: {
     map: mapSlice,
+    filter: filterSlice,
   },
   middleware: getDefaultMiddleware =>
     getDefaultMiddleware({


### PR DESCRIPTION
## 개요 :mag:

커피 가격, 용량 당 가격, 카페인 가격 및 따뜬한 커피, 아이스 커피 별로 필터링 기능을 추가하였습니다.

## 작업사항 :memo:

- 카카오맵 커스텀 오버레이를 생성하였습니다.
- 커스텀 오버레이에서 필터링 값을 사용하기 위해 해당 오버레이에 리덕스 프로바이더를 씌우고 필터링 값을 전역 상태로 관리하였습니다.
- 관련 이슈: #4 
- close : #4 